### PR TITLE
Add 'terraform-provider-github{file,teamapprover}'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 terraform-bundle/plugins/terraform-provider-*
 output/*.zip
 build/
+bin/fetch

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ This container is responsible for building a [Terraform Bundle](https://github.c
 is a custom terraform binary which contains the providers we need on a day to day basis.
 
 To update a version for a given provider or add a new one, edit the version in the `form3-bundle.json` file. The file is in JSON
-format, and each provider should have a `name`, `version` and `url` properties. Once you have made your changes, raise a PR, get
+format, and each provider should have a `name`, `version` and `url` properties.
+The value of the `version` field **MUST** correspond to an existing tag.
+Once you have made your changes, raise a PR, get
 it approved and once it's merged, it will trigger a Travis build which will generate the bundle, publish the generated ZIP file in Github as a Release 
 and call TFE's REST api so that the new bundle is installed automatically. You'll have to update the Terraform
 version used by the workspaces in TFE.

--- a/form3-bundle.json
+++ b/form3-bundle.json
@@ -4,52 +4,62 @@
     {
       "name": "form3",
       "url": "https://github.com/form3tech-oss/terraform-provider-form3",
-      "version": "0.30.0"
+      "version": "v0.30.0"
     },
     {
       "name": "acme",
       "url": "https://github.com/paybyphone/terraform-provider-acme",
-      "version": "0.6.0"
+      "version": "v0.6.0"
     },
     {
       "name": "kibana",
       "url": "https://github.com/ewilde/terraform-provider-kibana",
-      "version": "0.6.3"
+      "version": "v0.6.3"
     },
     {
       "name": "alienvault",
       "url": "https://github.com/form3tech-oss/terraform-provider-alienvault",
-      "version": "0.4.1"
+      "version": "v0.4.1"
     },
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "0.5.2"
+      "version": "v0.5.2"
     },
     {
       "name": "kong",
       "url": "https://github.com/kevholditch/terraform-provider-kong",
-      "version": "1.9.2"
+      "version": "v1.9.2"
     },
     {
       "name": "codeowners",
       "url": "https://github.com/form3tech-oss/terraform-provider-codeowners",
-      "version": "0.2.7"
+      "version": "v0.2.7"
     },
     {
       "name": "pagerduty",
       "url": "https://github.com/form3tech-oss/terraform-provider-pagerduty",
-      "version": "1.3.1-9-g1dbd8c8"
+      "version": "v1.3.1-9-g1dbd8c8"
     },
     {
       "name": "vault",
       "url": "https://github.com/form3tech-oss/terraform-provider-vault",
-      "version": "2.1.1"
+      "version": "v2.1.1"
     },
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "1.1.0-1-gf21c893"
+      "version": "v1.1.0-1-gf21c893"
+    },
+    {
+      "name": "githubteamapprover",
+      "url": "https://github.com/form3tech/terraform-provider-githubteamapprover",
+      "version": "v1.0.0"
+    },
+    {
+      "name": "githubfile",
+      "url": "https://github.com/form3tech-oss/terraform-provider-githubfile",
+      "version": "v1.0.0"
     }
   ]
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -66,7 +66,7 @@ function downloadProviders() {
         provider_name=$(echo $provider | jq -r '.name')
         provider_version=$(echo $provider | jq -r '.version')
         provider_url=$(echo $provider | jq -r '.url')
-        $scripts_dir/install_terraform_provider.sh $provider_name $provider_version $provider_url $TARGET_PLATFORM
+        $scripts_dir/install_terraform_provider.sh $provider_name $provider_version $provider_url $RUNNING_PLATFORM $TARGET_PLATFORM
     done
 }
 


### PR DESCRIPTION
This PR adds the `terraform-provider-githubfile` and `terraform-provider-githubteamapprover` providers to the bundle. As `terraform-provider-githubteamapprover` is closed-source, [`fetch`](https://github.com/gruntwork-io/fetch) is introduced in order to make downloading releases easier (as the current process using `wget` doesn't work with private repositories even if `GITHUB_TOKEN` is passed).