### PR TITLE
Roll the alient vault package version back to 0.4.1

### DIFF
--- a/form3-bundle-0.11.14.json
+++ b/form3-bundle-0.11.14.json
@@ -18,7 +18,7 @@
     {
       "name": "alienvault",
       "url": "https://github.com/form3tech-oss/terraform-provider-alienvault",
-      "version": "v0.5.1"
+      "version": "v0.4.1"
     },
     {
       "name": "auth0",


### PR DESCRIPTION
Fix issue causing some terraform workspaces to fail to run