### PR TITLE
Update the Kibana provider version to the latest

### DIFF
--- a/form3-bundle-0.11.14.json
+++ b/form3-bundle-0.11.14.json
@@ -13,7 +13,7 @@
     {
       "name": "kibana",
       "url": "https://github.com/ewilde/terraform-provider-kibana",
-      "version": "v0.6.3"
+      "version": "v0.7.1"
     },
     {
       "name": "alienvault",


### PR DESCRIPTION
Updating the latest version of the kibana provider to get the changes
that will fix the issues with the migration up to Kibana 7