### PR TITLE
Update logzio to v1.2.0

### DIFF
--- a/form3-bundle-0.11.14.json
+++ b/form3-bundle-0.11.14.json
@@ -43,7 +43,7 @@
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "v1.1.0-1-gf21c893"
+      "version": "v1.2.0"
     },
     {
       "name": "postgresreplication",

--- a/form3-bundle-0.12.10.json
+++ b/form3-bundle-0.12.10.json
@@ -48,7 +48,7 @@
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "v1.1.3"
+      "version": "v1.2.0"
     }
   ]
 }

--- a/form3-bundle-0.12.13.json
+++ b/form3-bundle-0.12.13.json
@@ -48,7 +48,7 @@
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "v1.1.3"
+      "version": "v1.2.0"
     }
   ]
 }

--- a/form3-bundle-0.12.17.json
+++ b/form3-bundle-0.12.17.json
@@ -48,7 +48,7 @@
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "v1.1.3"
+      "version": "v1.2.0"
     },
     {
       "name": "postgresreplication",

--- a/form3-bundle-0.12.19.json
+++ b/form3-bundle-0.12.19.json
@@ -48,7 +48,7 @@
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "v1.1.3"
+      "version": "v1.2.0"
     },
     {
       "name": "postgresreplication",

--- a/form3-bundle-0.12.21.json
+++ b/form3-bundle-0.12.21.json
@@ -48,7 +48,7 @@
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "v1.1.3"
+      "version": "v1.2.0"
     },
     {
       "name": "postgresreplication",

--- a/form3-bundle-0.12.24.json
+++ b/form3-bundle-0.12.24.json
@@ -48,7 +48,7 @@
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "v1.1.3"
+      "version": "v1.2.0"
     },
     {
       "name": "postgresreplication",

--- a/form3-bundle-0.12.9.json
+++ b/form3-bundle-0.12.9.json
@@ -48,7 +48,7 @@
     {
       "name": "logzio",
       "url": "https://github.com/form3tech-oss/logzio_terraform_provider",
-      "version": "v1.1.3"
+      "version": "v1.2.0"
     }
   ]
 }


### PR DESCRIPTION
Updated bundle to include latest Logzio provider:
https://github.com/form3tech-oss/logzio_terraform_provider/releases/tag/v1.2.0

This reduces unnecessary diffs in plans & adds retries to alerts reads as alerts seem to be eventually consistent.