### PR TITLE
Update auth0 version to 0.6.2

### DIFF
--- a/form3-bundle-0.11.14.json
+++ b/form3-bundle-0.11.14.json
@@ -23,7 +23,7 @@
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "v0.6.1"
+      "version": "v0.6.2"
     },
     {
       "name": "kong",

--- a/form3-bundle-0.12.10.json
+++ b/form3-bundle-0.12.10.json
@@ -33,7 +33,7 @@
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "v0.6.1"
+      "version": "v0.6.2"
     },
     {
       "name": "kong",

--- a/form3-bundle-0.12.13.json
+++ b/form3-bundle-0.12.13.json
@@ -33,7 +33,7 @@
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "v0.6.1"
+      "version": "v0.6.2"
     },
     {
       "name": "kong",

--- a/form3-bundle-0.12.17.json
+++ b/form3-bundle-0.12.17.json
@@ -33,7 +33,7 @@
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "v0.6.1"
+      "version": "v0.6.2"
     },
     {
       "name": "kong",

--- a/form3-bundle-0.12.19.json
+++ b/form3-bundle-0.12.19.json
@@ -33,7 +33,7 @@
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "v0.6.1"
+      "version": "v0.6.2"
     },
     {
       "name": "kong",

--- a/form3-bundle-0.12.21.json
+++ b/form3-bundle-0.12.21.json
@@ -33,7 +33,7 @@
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "v0.6.1"
+      "version": "v0.6.2"
     },
     {
       "name": "kong",

--- a/form3-bundle-0.12.24.json
+++ b/form3-bundle-0.12.24.json
@@ -33,7 +33,7 @@
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "v0.6.1"
+      "version": "v0.6.2"
     },
     {
       "name": "kong",

--- a/form3-bundle-0.12.9.json
+++ b/form3-bundle-0.12.9.json
@@ -33,7 +33,7 @@
     {
       "name": "auth0",
       "url": "https://github.com/form3tech-oss/terraform-provider-auth0",
-      "version": "v0.6.1"
+      "version": "v0.6.2"
     },
     {
       "name": "kong",


### PR DESCRIPTION
Auth0 provider can now correctly load the default (and overridden) delay between 429s (it was picking up 2ms rather than 1000 as default)


Signed-off-by: Alistair Hey <alistair.hey@form3.tech>