### PR TITLE
Bump version for the kong provider

### DIFF
--- a/form3-bundle-0.11.14.json
+++ b/form3-bundle-0.11.14.json
@@ -28,7 +28,7 @@
     {
       "name": "kong",
       "url": "https://github.com/kevholditch/terraform-provider-kong",
-      "version": "v1.9.2"
+      "version": "v1.11.0"
     },
     {
       "name": "pagerduty",

--- a/form3-bundle-0.12.25.json
+++ b/form3-bundle-0.12.25.json
@@ -38,7 +38,7 @@
     {
       "name": "kong",
       "url": "https://github.com/kevholditch/terraform-provider-kong",
-      "version": "v1.9.2"
+      "version": "v1.11.0"
     },
     {
       "name": "pagerduty",


### PR DESCRIPTION
Use version 0.11.0 of the kong provider, which has a better handling for config json objects.