### PR TITLE
Bump kong version for terraform 12

### DIFF
--- a/form3-bundle-0.12.25.json
+++ b/form3-bundle-0.12.25.json
@@ -38,7 +38,7 @@
     {
       "name": "kong",
       "url": "https://github.com/kevholditch/terraform-provider-kong",
-      "version": "v1.11.0"
+      "version": "v5.2.1"
     },
     {
       "name": "pagerduty",


### PR DESCRIPTION
The Kong provider only supports terraform12 from its version v5.0.0.