### PR TITLE
Add the docker target to the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TERRAFORM_VERSION ?= 0.11.14
 
-default: clean build publish
+default: clean build publish docker
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
In a previous PR, the possibility of publishing a docker container was added, but not used by default. We should publish the docker container every time for the `master` branch.