### PR TITLE
Add drp provider to the tf 0.12.31 bundle

### DIFF
--- a/form3-bundle-0.12.31.json
+++ b/form3-bundle-0.12.31.json
@@ -64,6 +64,11 @@
       "name": "megaport",
       "url": "https://github.com/megaport/terraform-provider-megaport",
       "version": "v0.1.4"
+    },
+    {
+      "name": "drp",
+      "url": "https://github.com/form3tech-oss/terraform-provider-drp",
+      "version": "v1.5.2"
     }
   ]
 }


### PR DESCRIPTION
Adds `drp` provider to TF `0.12.31` bundle in order to upgrade [infrastructure-dc-baremetal](https://github.com/form3tech/infrastructure-dc), part of https://github.com/form3tech/infrastructure/issues/3096