### PR TITLE
Ensure Travis build fails on errors

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 REPO_WORK_DIR="$(git rev-parse --show-toplevel)"
 TARGET_PLATFORM=$1
 TERRAFORM_VERSION=$2

--- a/scripts/clear.sh
+++ b/scripts/clear.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 WORK_DIR=$(git rev-parse --show-toplevel)
 
 if ls $WORK_DIR/build 1> /dev/null 2>&1; then

--- a/scripts/publish-docker.sh
+++ b/scripts/publish-docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 WORK_DIR="$(git rev-parse --show-toplevel)"
 TERRAFORM_VERSION=$1
 SIMPLIFIED_TERRAFORM_VERSION=""

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 TERRAFORM_VERSION=$1
 REPO="form3tech-oss/terraform-bundler"
 WORK_DIR="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
This PR changes the build scripts to ensure that failures during bundling are detected properly and bubble up to Travis. Otherwise builds may appear successful, while in fact, they're failing.