### PR TITLE
Revert "Add kong provider to newer bundles"

### DIFF
--- a/form3-bundle-0.13.7.json
+++ b/form3-bundle-0.13.7.json
@@ -4,11 +4,6 @@
       "name": "grafanacloud",
       "url": "https://github.com/form3tech-oss/terraform-provider-grafanacloud",
       "version": "v0.1.0"
-    },
-    {
-      "name": "kong",
-      "url": "https://github.com/kevholditch/terraform-provider-kong",
-      "version": "v1.12.0"
     }
   ]
 }

--- a/form3-bundle-0.14.11.json
+++ b/form3-bundle-0.14.11.json
@@ -4,11 +4,6 @@
       "name": "grafanacloud",
       "url": "https://github.com/form3tech-oss/terraform-provider-grafanacloud",
       "version": "v0.1.0"
-    },
-    {
-      "name": "kong",
-      "url": "https://github.com/kevholditch/terraform-provider-kong",
-      "version": "v1.12.0"
     }
   ]
 }

--- a/form3-bundle-0.15.1.json
+++ b/form3-bundle-0.15.1.json
@@ -4,11 +4,6 @@
       "name": "grafanacloud",
       "url": "https://github.com/form3tech-oss/terraform-provider-grafanacloud",
       "version": "v0.1.0"
-    },
-    {
-      "name": "kong",
-      "url": "https://github.com/kevholditch/terraform-provider-kong",
-      "version": "v1.12.0"
     }
   ]
 }


### PR DESCRIPTION
Reverts form3tech-oss/terraform-bundler#180

The kong provider doesn't work on versions >0.12 of terraform.