### PR TITLE
Update form3 provider to use new sepainstant association

### DIFF
--- a/form3-bundle-0.11.15.json
+++ b/form3-bundle-0.11.15.json
@@ -3,7 +3,7 @@
     {
       "name": "form3",
       "url": "https://github.com/form3tech-oss/terraform-provider-form3",
-      "version": "v0.44.35"
+      "version": "v0.44.36"
     },
     {
       "name": "acme",

--- a/form3-bundle-0.12.31.json
+++ b/form3-bundle-0.12.31.json
@@ -3,7 +3,7 @@
     {
       "name": "form3",
       "url": "https://github.com/form3tech-oss/terraform-provider-form3",
-      "version": "v0.44.35"
+      "version": "v0.44.36"
     },
     {
       "name": "alienvault",


### PR DESCRIPTION
The form3 provider now supports the clearing_system flag in the
association.

Co-authored-by: Petar Dochev <petar.dochev@form3.tech>